### PR TITLE
Exit: remove definitions for _fini_array_*

### DIFF
--- a/src/exit/exit.c
+++ b/src/exit/exit.c
@@ -12,13 +12,17 @@ weak_alias(dummy, __funcs_on_exit);
 weak_alias(dummy, __stdio_exit);
 weak_alias(dummy, _fini);
 
+#ifndef __CHEERP__
 extern weak hidden void (*const __fini_array_start)(void), (*const __fini_array_end)(void);
+#endif
 
 static void libc_exit_fini(void)
 {
+#ifndef __CHEERP__
 	uintptr_t a = (uintptr_t)&__fini_array_end;
 	for (; a>(uintptr_t)&__fini_array_start; a-=sizeof(void(*)()))
 		(*(void (**)())(a-sizeof(void(*)())))();
+#endif
 	_fini();
 }
 


### PR DESCRIPTION
Minimal test case:
`#include <stdlib.h>
int main()
{
        exit(23);
        return 1;
}
`
/opt/cheerp/bin/clang++ file.cpp -> crash in the WasmWriter since the GlobalVariables are nowhere to be found.
Cheerp side possibly we could be more robust (eg. GDA during llc -> warning + setting to undefined), but should be harmless removing them from libc (since I believe they are only useful for dynamic linking).