### PR TITLE
Fix compiler error

### DIFF
--- a/src/aio/lio_listio.c
+++ b/src/aio/lio_listio.c
@@ -83,7 +83,7 @@ int lio_listio(int mode, struct aiocb *restrict const *restrict cbs, int cnt, st
 		}
 		st->cnt = cnt;
 		st->sev = sev;
-		memcpy(st->cbs, cbs, cnt*sizeof *cbs);
+		memcpy(st->cbs, (void*) cbs, cnt*sizeof *cbs);
 	}
 
 	for (i=0; i<cnt; i++) {


### PR DESCRIPTION
Caused discarded-qualifiers error on my system.

Seems to have been fixed in musl a while back with https://github.com/bminor/musl/commit/400c5e5c8307a2ebe44ef1f203f5a15669f20347

Using:
Linux: `Linux arch 6.4.12-arch1-1`
gcc: `13.2.1 20230801`