### PR TITLE
Make memory functions weak aliases

### DIFF
--- a/src/malloc/dlmalloc/malloc.c
+++ b/src/malloc/dlmalloc/malloc.c
@@ -846,6 +846,22 @@ extern "C" {
 #define dlindependent_calloc   independent_calloc
 #define dlindependent_comalloc independent_comalloc
 #define dlbulk_free            bulk_free
+#else /* USE_DL_PREFIX */
+
+#define CHEERP_DEFINE_MEMFUNC(name, ret, ...) \
+  __attribute__ ((__weak__, alias("dl"#name))) ret name(__VA_ARGS__); \
+  __attribute__ ((alias("dl"#name))) ret __cheerp_##name(__VA_ARGS__);
+
+CHEERP_DEFINE_MEMFUNC(malloc, void*, size_t)
+CHEERP_DEFINE_MEMFUNC(calloc, void*, size_t, size_t)
+CHEERP_DEFINE_MEMFUNC(realloc, void*, void*, size_t)
+CHEERP_DEFINE_MEMFUNC(free, void, void*)
+CHEERP_DEFINE_MEMFUNC(valloc, void*, size_t)
+CHEERP_DEFINE_MEMFUNC(memalign, void*, size_t, size_t)
+CHEERP_DEFINE_MEMFUNC(malloc_usable_size, size_t, void*)
+
+#undef CHEERP_DEFINE_MEMFUNC
+
 #endif /* USE_DL_PREFIX */
 
 /*


### PR DESCRIPTION
This PR makes all memory function declared in `include/malloc.h` weak aliases to their dlmalloc variant. This will be needed for implementing AddressSanitizer.

It is disabled by default, and can be enabled during compilation by specifying the define `USE_DL_PREFIX`

I've also made `__cheerp_*` functions for each memory function. AddressSanitizer will want to call the actual memory functions (dlmalloc etc.), but I figured it would be better to abstract that away so the implementation could be changed.

This requires https://github.com/leaningtech/cheerp-compiler/pull/156 to work.