### PR TITLE
Weak functions

### DIFF
--- a/src/multibyte/mbsrtowcs.c
+++ b/src/multibyte/mbsrtowcs.c
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include "internal.h"
 
-size_t mbsrtowcs(wchar_t *restrict ws, const char **restrict src, size_t wn, mbstate_t *restrict st)
+size_t __mbsrtowcs(wchar_t *restrict ws, const char **restrict src, size_t wn, mbstate_t *restrict st)
 {
 	const unsigned char *s = (const void *)*src;
 	size_t wn0 = wn;
@@ -118,3 +118,6 @@ resume:
 	if (ws) *src = (const void *)s;
 	return -1;
 }
+
+__attribute__ ((__weak__, alias("__mbsrtowcs"))) size_t mbsrtowcs(wchar_t *restrict ws, const char **restrict src, size_t wn, mbstate_t *restrict st);
+__attribute__ ((alias("__mbsrtowcs"))) size_t __cheerp_mbsrtowcs(wchar_t *restrict ws, const char **restrict src, size_t wn, mbstate_t *restrict st);

--- a/src/multibyte/mbstowcs.c
+++ b/src/multibyte/mbstowcs.c
@@ -1,7 +1,10 @@
 #include <stdlib.h>
 #include <wchar.h>
 
-size_t mbstowcs(wchar_t *restrict ws, const char *restrict s, size_t wn)
+size_t __mbstowcs(wchar_t *restrict ws, const char *restrict s, size_t wn)
 {
 	return mbsrtowcs(ws, (void*)&s, wn, 0);
 }
+
+__attribute__ ((__weak__, alias("__mbstowcs"))) size_t mbstowcs(wchar_t *restrict ws, const char *restrict s, size_t wn);
+__attribute__ ((alias("__mbstowcs"))) size_t __cheerp_mbstowcs(wchar_t *restrict ws, const char *restrict s, size_t wn);

--- a/src/stdio/asprintf.c
+++ b/src/stdio/asprintf.c
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 
-int asprintf(char **s, const char *fmt, ...)
+int __asprintf(char **s, const char *fmt, ...)
 {
 	int ret;
 	va_list ap;
@@ -11,3 +11,6 @@ int asprintf(char **s, const char *fmt, ...)
 	va_end(ap);
 	return ret;
 }
+
+__attribute__ ((__weak__, alias("__asprintf"))) int asprintf(char **s, const char *fmt, ...);
+__attribute__ ((alias("__asprintf"))) int __cheerp_asprintf(char **s, const char *fmt, ...);

--- a/src/stdio/fprintf.c
+++ b/src/stdio/fprintf.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 
-int fprintf(FILE *restrict f, const char *restrict fmt, ...)
+int __fprintf(FILE *restrict f, const char *restrict fmt, ...)
 {
 	int ret;
 	va_list ap;
@@ -10,3 +10,6 @@ int fprintf(FILE *restrict f, const char *restrict fmt, ...)
 	va_end(ap);
 	return ret;
 }
+
+__attribute__ ((__weak__, alias("__fprintf"))) int fprintf(FILE *restrict f, const char *restrict fmt, ...);
+__attribute__ ((alias("__fprintf"))) int __cheerp_fprintf(FILE *restrict f, const char *restrict fmt, ...);

--- a/src/stdio/fputs.c
+++ b/src/stdio/fputs.c
@@ -1,10 +1,13 @@
 #include "stdio_impl.h"
 #include <string.h>
 
-int fputs(const char *restrict s, FILE *restrict f)
+int __fputs(const char *restrict s, FILE *restrict f)
 {
 	size_t l = strlen(s);
 	return (fwrite(s, 1, l, f)==l) - 1;
 }
+
+__attribute__ ((__weak__, alias("__fputs"))) int fputs(const char *restrict s, FILE *restrict f);
+__attribute__ ((alias("__fputs"))) int __cheerp_fputs(const char *restrict s, FILE *restrict f);
 
 weak_alias(fputs, fputs_unlocked);

--- a/src/stdio/fwrite.c
+++ b/src/stdio/fwrite.c
@@ -25,7 +25,7 @@ size_t __fwritex(const unsigned char *restrict s, size_t l, FILE *restrict f)
 	return l+i;
 }
 
-size_t fwrite(const void *restrict src, size_t size, size_t nmemb, FILE *restrict f)
+size_t __fwrite(const void *restrict src, size_t size, size_t nmemb, FILE *restrict f)
 {
 	size_t k, l = size*nmemb;
 	if (!size) nmemb = 0;
@@ -36,3 +36,6 @@ size_t fwrite(const void *restrict src, size_t size, size_t nmemb, FILE *restric
 }
 
 weak_alias(fwrite, fwrite_unlocked);
+
+__attribute__ ((__weak__, alias("__fwrite"))) size_t fwrite(const void *restrict src, size_t size, size_t nmemb, FILE *restrict f);
+__attribute__ ((alias("__fwrite"))) size_t __cheerp_fwrite(const void *restrict src, size_t size, size_t nmemb, FILE *restrict f);

--- a/src/stdio/printf.c
+++ b/src/stdio/printf.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 
-int printf(const char *restrict fmt, ...)
+int __printf(const char *restrict fmt, ...)
 {
 	int ret;
 	va_list ap;
@@ -10,3 +10,6 @@ int printf(const char *restrict fmt, ...)
 	va_end(ap);
 	return ret;
 }
+
+__attribute__ ((__weak__, alias("__printf"))) int printf(const char *restrict fmt, ...);
+__attribute__ ((alias("__printf"))) int __cheerp_printf(const char *restrict fmt, ...);

--- a/src/stdio/snprintf.c
+++ b/src/stdio/snprintf.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 
-int snprintf(char *restrict s, size_t n, const char *restrict fmt, ...)
+int __snprintf(char *restrict s, size_t n, const char *restrict fmt, ...)
 {
 	int ret;
 	va_list ap;
@@ -11,3 +11,6 @@ int snprintf(char *restrict s, size_t n, const char *restrict fmt, ...)
 	return ret;
 }
 
+
+__attribute__ ((__weak__, alias("__snprintf"))) int snprintf(char *restrict s, size_t n, const char *restrict fmt, ...);
+__attribute__ ((alias("__snprintf"))) int __cheerp_snprintf(char *restrict s, size_t n, const char *restrict fmt, ...);

--- a/src/stdio/sprintf.c
+++ b/src/stdio/sprintf.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 
-int sprintf(char *restrict s, const char *restrict fmt, ...)
+int __sprintf(char *restrict s, const char *restrict fmt, ...)
 {
 	int ret;
 	va_list ap;
@@ -10,3 +10,6 @@ int sprintf(char *restrict s, const char *restrict fmt, ...)
 	va_end(ap);
 	return ret;
 }
+
+__attribute__ ((__weak__, alias("__sprintf"))) int sprintf(char *restrict s, const char *restrict fmt, ...);
+__attribute__ ((alias("__sprintf"))) int __cheerp_sprintf(char *restrict s, const char *restrict fmt, ...);

--- a/src/stdio/vasprintf.c
+++ b/src/stdio/vasprintf.c
@@ -3,7 +3,7 @@
 #include <stdarg.h>
 #include <stdlib.h>
 
-int vasprintf(char **s, const char *fmt, va_list ap)
+int __vasprintf(char **s, const char *fmt, va_list ap)
 {
 	va_list ap2;
 	va_copy(ap2, ap);
@@ -13,3 +13,6 @@ int vasprintf(char **s, const char *fmt, va_list ap)
 	if (l<0 || !(*s=malloc(l+1U))) return -1;
 	return vsnprintf(*s, l+1U, fmt, ap);
 }
+
+__attribute__ ((__weak__, alias("__vasprintf"))) int vasprintf(char **s, const char *fmt, va_list ap);
+__attribute__ ((alias("__vasprintf"))) int __cheerp_vasprintf(char **s, const char *fmt, va_list ap);

--- a/src/stdio/vfprintf.c
+++ b/src/stdio/vfprintf.c
@@ -660,7 +660,7 @@ overflow:
 	return -1;
 }
 
-int vfprintf(FILE *restrict f, const char *restrict fmt, va_list ap)
+int __vfprintf(FILE *restrict f, const char *restrict fmt, va_list ap)
 {
 	va_list ap2;
 	int nl_type[NL_ARGMAX+1] = {0};
@@ -700,3 +700,6 @@ int vfprintf(FILE *restrict f, const char *restrict fmt, va_list ap)
 	va_end(ap2);
 	return ret;
 }
+
+__attribute__ ((__weak__, alias("__vfprintf"))) int vfprintf(FILE *restrict f, const char *restrict fmt, va_list ap);
+__attribute__ ((alias("__vfprintf"))) int __cheerp_vfprintf(FILE *restrict f, const char *restrict fmt, va_list ap);

--- a/src/stdio/vprintf.c
+++ b/src/stdio/vprintf.c
@@ -1,6 +1,9 @@
 #include <stdio.h>
 
-int vprintf(const char *restrict fmt, va_list ap)
+int __vprintf(const char *restrict fmt, va_list ap)
 {
 	return vfprintf(stdout, fmt, ap);
 }
+
+__attribute__ ((__weak__, alias("__vprintf"))) int vprintf(const char *restrict fmt, va_list ap);
+__attribute__ ((alias("__vprintf"))) int __cheerp_vprintf(const char *restrict fmt, va_list ap);

--- a/src/stdio/vsnprintf.c
+++ b/src/stdio/vsnprintf.c
@@ -32,7 +32,7 @@ static size_t sn_write(FILE *f, const unsigned char *s, size_t l)
 	return l;
 }
 
-int vsnprintf(char *restrict s, size_t n, const char *restrict fmt, va_list ap)
+int __vsnprintf(char *restrict s, size_t n, const char *restrict fmt, va_list ap)
 {
 	unsigned char buf[1];
 	char dummy[1];
@@ -53,3 +53,6 @@ int vsnprintf(char *restrict s, size_t n, const char *restrict fmt, va_list ap)
 	*c.s = 0;
 	return vfprintf(&f, fmt, ap);
 }
+
+__attribute__ ((__weak__, alias("__vsnprintf"))) int vsnprintf(char *restrict s, size_t n, const char *restrict fmt, va_list ap);
+__attribute__ ((alias("__vsnprintf"))) int __cheerp_vsnprintf(char *restrict s, size_t n, const char *restrict fmt, va_list ap);

--- a/src/stdio/vsprintf.c
+++ b/src/stdio/vsprintf.c
@@ -1,7 +1,10 @@
 #include <stdio.h>
 #include <limits.h>
 
-int vsprintf(char *restrict s, const char *restrict fmt, va_list ap)
+int __vsprintf(char *restrict s, const char *restrict fmt, va_list ap)
 {
 	return vsnprintf(s, INT_MAX, fmt, ap);
 }
+
+__attribute__ ((__weak__, alias("__vsprintf"))) int vsprintf(char *restrict s, const char *restrict fmt, va_list ap);
+__attribute__ ((alias("__vsprintf"))) int __cheerp_vsprintf(char *restrict s, const char *restrict fmt, va_list ap);

--- a/src/stdlib/atoi.c
+++ b/src/stdlib/atoi.c
@@ -1,7 +1,7 @@
 #include <stdlib.h>
 #include <ctype.h>
 
-int atoi(const char *s)
+int __atoi(const char *s)
 {
 	int n=0, neg=0;
 	while (isspace(*s)) s++;
@@ -14,3 +14,6 @@ int atoi(const char *s)
 		n = 10*n - (*s++ - '0');
 	return neg ? n : -n;
 }
+
+__attribute__ ((__weak__, alias("__atoi"))) int atoi(const char *s);
+__attribute__ ((alias("__atoi"))) int __cheerp_atoi(const char *s);

--- a/src/stdlib/atol.c
+++ b/src/stdlib/atol.c
@@ -1,7 +1,7 @@
 #include <stdlib.h>
 #include <ctype.h>
 
-long atol(const char *s)
+long __atol(const char *s)
 {
 	long n=0;
 	int neg=0;
@@ -15,3 +15,6 @@ long atol(const char *s)
 		n = 10*n - (*s++ - '0');
 	return neg ? n : -n;
 }
+
+__attribute__ ((__weak__, alias("__atol"))) long atol(const char *s);
+__attribute__ ((alias("__atol"))) long __cheerp_atol(const char *s);

--- a/src/stdlib/strtol.c
+++ b/src/stdlib/strtol.c
@@ -33,7 +33,7 @@ unsigned long strtoul(const char *restrict s, char **restrict p, int base)
 	return strtox(s, p, base, ULONG_MAX);
 }
 
-long strtol(const char *restrict s, char **restrict p, int base)
+long __strtol(const char *restrict s, char **restrict p, int base)
 {
 	return strtox(s, p, base, 0UL+LONG_MIN);
 }
@@ -47,6 +47,9 @@ uintmax_t strtoumax(const char *restrict s, char **restrict p, int base)
 {
 	return strtoull(s, p, base);
 }
+
+__attribute__ ((__weak__, alias("__strtol"))) long strtol(const char *restrict s, char **restrict p, int base);
+__attribute__ ((alias("__strtol"))) long __cheerp_strtol(const char *restrict s, char **restrict p, int base);
 
 weak_alias(strtol, __strtol_internal);
 weak_alias(strtoul, __strtoul_internal);

--- a/src/string/memcpy.c
+++ b/src/string/memcpy.c
@@ -2,7 +2,7 @@
 #include <stdint.h>
 #include <endian.h>
 
-weak void *memcpy(void *restrict dest, const void *restrict src, size_t n)
+void *__memcpy(void *restrict dest, const void *restrict src, size_t n)
 {
 	unsigned char *d = dest;
 	const unsigned char *s = src;
@@ -122,3 +122,6 @@ weak void *memcpy(void *restrict dest, const void *restrict src, size_t n)
 	for (; n; n--) *d++ = *s++;
 	return dest;
 }
+
+__attribute__ ((__weak__, alias("__memcpy"))) void* memcpy(void *dest, const void *src, size_t n);
+__attribute__ ((alias("__memcpy"))) void* __cheerp_memcpy(void *dest, const void *src, size_t n);

--- a/src/string/memcpy.c
+++ b/src/string/memcpy.c
@@ -123,5 +123,5 @@ void *__memcpy(void *restrict dest, const void *restrict src, size_t n)
 	return dest;
 }
 
-__attribute__ ((__weak__, alias("__memcpy"))) void* memcpy(void *dest, const void *src, size_t n);
-__attribute__ ((alias("__memcpy"))) void* __cheerp_memcpy(void *dest, const void *src, size_t n);
+__attribute__ ((__weak__, alias("__memcpy"))) void* memcpy(void *restrict dest, const void *restrict src, size_t n);
+__attribute__ ((alias("__memcpy"))) void* __cheerp_memcpy(void *restrict dest, const void *restrict src, size_t n);

--- a/src/string/memmove.c
+++ b/src/string/memmove.c
@@ -6,7 +6,7 @@ typedef __attribute__((__may_alias__)) size_t WT;
 #define WS (sizeof(WT))
 #endif
 
-void *memmove(void *dest, const void *src, size_t n)
+void *__memmove(void *dest, const void *src, size_t n)
 {
 	char *d = dest;
 	const char *s = src;
@@ -40,3 +40,6 @@ void *memmove(void *dest, const void *src, size_t n)
 
 	return dest;
 }
+
+__attribute__ ((__weak__, alias("__memmove"))) void* memmove(void*dest, const void *src, size_t n);
+__attribute__ ((alias("__memmove"))) void* cheerp_memmove(void*dest, const void *src, size_t n);

--- a/src/string/memmove.c
+++ b/src/string/memmove.c
@@ -42,4 +42,4 @@ void *__memmove(void *dest, const void *src, size_t n)
 }
 
 __attribute__ ((__weak__, alias("__memmove"))) void* memmove(void*dest, const void *src, size_t n);
-__attribute__ ((alias("__memmove"))) void* cheerp_memmove(void*dest, const void *src, size_t n);
+__attribute__ ((alias("__memmove"))) void* __cheerp_memmove(void*dest, const void *src, size_t n);

--- a/src/string/memset.c
+++ b/src/string/memset.c
@@ -1,7 +1,7 @@
 #include <string.h>
 #include <stdint.h>
 
-weak void *memset(void *dest, int c, size_t n)
+void *__memset(void *dest, int c, size_t n)
 {
 	unsigned char *s = dest;
 	size_t k;
@@ -88,3 +88,6 @@ weak void *memset(void *dest, int c, size_t n)
 
 	return dest;
 }
+
+__attribute__ ((__weak__, alias("__memset"))) void* memset(void* s, int  c, size_t n);
+__attribute__ ((alias("__memset"))) void* __cheerp_memset(void* s, int  c, size_t n);

--- a/src/string/strcasestr.c
+++ b/src/string/strcasestr.c
@@ -1,9 +1,12 @@
 #define _GNU_SOURCE
 #include <string.h>
 
-char *strcasestr(const char *h, const char *n)
+char *__strcasestr(const char *h, const char *n)
 {
 	size_t l = strlen(n);
 	for (; *h; h++) if (!strncasecmp(h, n, l)) return (char *)h;
 	return 0;
 }
+
+__attribute__ ((__weak__, alias("__strcasestr"))) char *strcasestr(const char *h, const char *n);
+__attribute__ ((alias("__strcasestr"))) char *__cheerp_strcasestr(const char *h, const char *n);

--- a/src/string/strcat.c
+++ b/src/string/strcat.c
@@ -1,7 +1,10 @@
 #include <string.h>
 
-char *strcat(char *restrict dest, const char *restrict src)
+char *__strcat(char *restrict dest, const char *restrict src)
 {
 	strcpy(dest + strlen(dest), src);
 	return dest;
 }
+
+__attribute__ ((__weak__, alias("__strcat"))) char *strcat(char *restrict dest, const char *restrict src);
+__attribute__ ((alias("__strcat"))) char *__cheerp_strcat(char *restrict dest, const char *restrict src);

--- a/src/string/strchr.c
+++ b/src/string/strchr.c
@@ -1,7 +1,9 @@
 #include <string.h>
 
-char *strchr(const char *s, int c)
+char *__strchr(const char *s, int c)
 {
 	char *r = __strchrnul(s, c);
 	return *(unsigned char *)r == (unsigned char)c ? r : 0;
 }
+__attribute__ ((__weak__, alias("__strchr"))) char *strchr(const char *s, int c);
+__attribute__ ((alias("__strchr"))) char *__cheerp__strchr(const char *s, int c);

--- a/src/string/strcmp.c
+++ b/src/string/strcmp.c
@@ -1,7 +1,10 @@
 #include <string.h>
 
-int strcmp(const char *l, const char *r)
+int __strcmp(const char *l, const char *r)
 {
 	for (; *l==*r && *l; l++, r++);
 	return *(unsigned char *)l - *(unsigned char *)r;
 }
+
+__attribute__ ((__weak__, alias("__strcmp"))) int strcmp(const char *l, const char *r);
+__attribute__ ((alias("__strcmp"))) int __cheerp_strcmp(const char *l, const char *r);

--- a/src/string/strcpy.c
+++ b/src/string/strcpy.c
@@ -1,7 +1,10 @@
 #include <string.h>
 
-char *strcpy(char *restrict dest, const char *restrict src)
+char *__strcpy(char *restrict dest, const char *restrict src)
 {
 	__stpcpy(dest, src);
 	return dest;
 }
+
+__attribute__ ((__weak__, alias("__strcpy"))) char *strcpy(char *restrict dest, const char *restrict src);
+__attribute__ ((alias("__strcpy"))) char *__cheerp_strcpy(char *restrict dest, const char *restrict src);

--- a/src/string/strdup.c
+++ b/src/string/strdup.c
@@ -1,10 +1,13 @@
 #include <stdlib.h>
 #include <string.h>
 
-char *strdup(const char *s)
+char *__strdup(const char *s)
 {
 	size_t l = strlen(s);
 	char *d = malloc(l+1);
 	if (!d) return NULL;
 	return memcpy(d, s, l+1);
 }
+
+__attribute__ ((__weak__, alias("__strdup"))) char *strdup(const char *s);
+__attribute__ ((alias("__strdup"))) char *__cheerp_strdup(const char *s);

--- a/src/string/strlen.c
+++ b/src/string/strlen.c
@@ -7,7 +7,7 @@
 #define HIGHS (ONES * (UCHAR_MAX/2+1))
 #define HASZERO(x) ((x)-ONES & ~(x) & HIGHS)
 
-size_t strlen(const char *s)
+size_t __strlen(const char *s)
 {
 	const char *a = s;
 #if defined(__GNUC__) && !(defined(__CHEERP__) && !defined(__ASMJS__))
@@ -20,3 +20,6 @@ size_t strlen(const char *s)
 	for (; *s; s++);
 	return s-a;
 }
+
+__attribute__ ((__weak__, alias("__strlen"))) size_t strlen(const char *s);
+__attribute__ ((alias("__strlen"))) size_t __cheerp_strlen(const char *s);

--- a/src/string/strncat.c
+++ b/src/string/strncat.c
@@ -1,6 +1,6 @@
 #include <string.h>
 
-char *strncat(char *restrict d, const char *restrict s, size_t n)
+char *__strncat(char *restrict d, const char *restrict s, size_t n)
 {
 	char *a = d;
 	d += strlen(d);
@@ -8,3 +8,6 @@ char *strncat(char *restrict d, const char *restrict s, size_t n)
 	*d++ = 0;
 	return a;
 }
+
+__attribute__ ((__weak__, alias("__strncat"))) char *strncat(char *restrict d, const char *restrict s, size_t n);
+__attribute__ ((alias("__strncat"))) char *__cheerp_strncat(char *restrict d, const char *restrict s, size_t n);

--- a/src/string/strncmp.c
+++ b/src/string/strncmp.c
@@ -1,9 +1,12 @@
 #include <string.h>
 
-int strncmp(const char *_l, const char *_r, size_t n)
+int __strncmp(const char *_l, const char *_r, size_t n)
 {
 	const unsigned char *l=(void *)_l, *r=(void *)_r;
 	if (!n--) return 0;
 	for (; *l && *r && n && *l == *r ; l++, r++, n--);
 	return *l - *r;
 }
+
+__attribute__ ((__weak__, alias("__strncmp"))) int strncmp(const char *_l, const char *_r, size_t n);
+__attribute__ ((alias("__strncmp"))) int __cheerp_strncmp(const char *_l, const char *_r, size_t n);

--- a/src/string/strncpy.c
+++ b/src/string/strncpy.c
@@ -1,7 +1,9 @@
 #include <string.h>
 
-char *strncpy(char *restrict d, const char *restrict s, size_t n)
+char *__strncpy(char *restrict d, const char *restrict s, size_t n)
 {
 	__stpncpy(d, s, n);
 	return d;
 }
+__attribute__ ((__weak__, alias("__strncpy"))) char *strncpy(char *restrict d, const char *restrict s, size_t n);
+__attribute__ ((alias("__strncpy"))) char *__cheerp_strncpy(char *restrict d, const char *restrict s, size_t n);

--- a/src/string/strnlen.c
+++ b/src/string/strnlen.c
@@ -1,7 +1,9 @@
 #include <string.h>
 
-size_t strnlen(const char *s, size_t n)
+size_t __strnlen(const char *s, size_t n)
 {
 	const char *p = memchr(s, 0, n);
 	return p ? p-s : n;
 }
+__attribute__ ((__weak__, alias("__strnlen"))) size_t strnlen(const char *s, size_t n);
+__attribute__ ((alias("__strnlen"))) size_t __cheerp_strnlen(const char *s, size_t n);

--- a/src/string/strstr.c
+++ b/src/string/strstr.c
@@ -135,7 +135,7 @@ static char *twoway_strstr(const unsigned char *h, const unsigned char *n)
 	}
 }
 
-char *strstr(const char *h, const char *n)
+char *__strstr(const char *h, const char *n)
 {
 	/* Return immediately on empty needle */
 	if (!n[0]) return (char *)h;
@@ -152,3 +152,6 @@ char *strstr(const char *h, const char *n)
 
 	return twoway_strstr((void *)h, (void *)n);
 }
+
+__attribute__ ((__weak__, alias("__strstr"))) char *strstr(const char *h, const char *n);
+__attribute__ ((alias("__strstr"))) char *__cheerp_strstr(const char *h, const char *n);


### PR DESCRIPTION
Requires: https://github.com/leaningtech/cheerp-compiler/tree/feat-weak-string-funcs

This change makes a bunch of functions weak aliases so that they can be intercepted in asan. I considered making a preprocessor macro to make it less repeating, however I wasn't really sure in which header I'd put it.

There are probably more functions that are good to have as weak functions, however this is a good start.