### PR TITLE
Enable weak allocation functions

### DIFF
--- a/src/malloc/dlmalloc/malloc-params.h
+++ b/src/malloc/dlmalloc/malloc-params.h
@@ -4,6 +4,7 @@
 #define MORECORE_CANNOT_TRIM 1
 #define malloc_getpagesize (64*1024)
 #define DEFAULT_GRANULARITY malloc_getpagesize
+#define USE_DL_PREFIX 1
 
 #ifdef __CHEERP__
 __attribute__((cheerp_wasm))


### PR DESCRIPTION
Although the code for weak allocation functions was already there, it wasn't enabled. In preparation for the ASan PR, I'd like to enable it by default for cheerp-wasm.

As for testing, [this](https://app.circleci.com/pipelines/github/leaningtech/cheerp-compiler/1057) workflow was built using this change.