### PR TITLE
Malloc: Prefer using heapStart to the lower precise syscall when poss…

### DIFF
--- a/src/malloc/dlmalloc/malloc-params.h
+++ b/src/malloc/dlmalloc/malloc-params.h
@@ -23,3 +23,8 @@ static inline void set_errno()
 	errno = ENOMEM;
 }
 #define MALLOC_FAILURE_ACTION set_errno();
+
+#if defined(__CHEERP__) && defined(__ASMJS__)
+// This value is defined in cheerp-libs, in system/common.cpp
+__attribute__((cheerp_asmjs)) extern char* volatile _heapStart;
+#endif

--- a/src/malloc/dlmalloc/malloc.c
+++ b/src/malloc/dlmalloc/malloc.c
@@ -4698,11 +4698,6 @@ void* dlmalloc(size_t bytes) {
 
 /* ---------------------------- free --------------------------- */
 
-#if defined(__CHEERP__) && defined(__ASMJS__)
-// This value is defined in cheerp-libs, in system/common.cpp
-__attribute__((cheerp_asmjs)) extern char* volatile _heapStart;
-#endif
-
 void dlfree(void* mem) {
   /*
      Consolidate freed chunks with preceeding or succeeding bordering

--- a/src/malloc/dlmalloc/morecore.c
+++ b/src/malloc/dlmalloc/morecore.c
@@ -8,7 +8,12 @@ void* dlmalloc_morecore(int size)
 	static char* end = 0;
 	if (!end)
 	{
-		end = (char*)SYS_brk(0);
+		// Use the compiler-provided heapStart if valid, otherwise
+		// resort to the syscall, which might might be less precise
+		if (_heapStart > 4)
+			end = _heapStart;
+		else
+			end = (char*)SYS_brk(0);
 	}
 	char* ret = (char*)SYS_brk(end+size);
 	if (ret < end + size)


### PR DESCRIPTION
…ible

_heapStart is not fully populated in shared modules, since global addresses are allocated dynamically