### PR TITLE
disable memmove/memcpy/memset defs in genericjs builds

### DIFF
--- a/include/sched.h
+++ b/include/sched.h
@@ -78,10 +78,7 @@ int clone (int (*)(void *), void *, int, void *, ...);
 int unshare(int);
 int setns(int, int);
 
-// This pragma disables cheerp attribute injection and address space deduction
-// These are builtins that can be used from both js and wasm
-#pragma cheerp env none
-#if defined(__CHEERP__) && (defined(INTERNAL_MUSL) || !defined(__GENERICJS__))
+#if defined(__CHEERP__) && (defined(__ASMJS__))
 #define MAYBE_ASMJS __attribute((cheerp_asmjs))
 #else
 #define MAYBE_ASMJS
@@ -90,7 +87,6 @@ MAYBE_ASMJS void *memcpy(void *__restrict, const void *__restrict, size_t);
 MAYBE_ASMJS void *memset (void *, int, size_t);
 MAYBE_ASMJS void *calloc(size_t, size_t);
 MAYBE_ASMJS void free(void *);
-#pragma cheerp env reset
 int memcmp(const void *, const void *, size_t);
 
 typedef struct cpu_set_t { unsigned long __bits[128/sizeof(long)]; } cpu_set_t;

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -35,10 +35,7 @@ unsigned long long strtoull (const char *__restrict, char **__restrict, int);
 int rand (void);
 void srand (unsigned);
 
-// This pragma disables cheerp attribute injection and address space deduction
-// These are builtins that can be used from both js and wasm
-#pragma cheerp env none
-#if defined(__CHEERP__) && (defined(INTERNAL_MUSL) || !defined(__GENERICJS__))
+#if defined(__CHEERP__) && (defined(__ASMJS__))
 #define MAYBE_ASMJS __attribute((cheerp_asmjs))
 #else
 #define MAYBE_ASMJS
@@ -49,7 +46,6 @@ MAYBE_ASMJS void *realloc (void *, size_t);
 MAYBE_ASMJS void free (void *);
 MAYBE_ASMJS void *aligned_alloc(size_t, size_t);
 #undef MAYBE_ASMJS
-#pragma cheerp env reset
 
 _Noreturn void abort (void);
 int atexit (void (*) (void));

--- a/include/string.h
+++ b/include/string.h
@@ -22,10 +22,7 @@ extern "C" {
 
 #include <bits/alltypes.h>
 
-// This pragma disables cheerp attribute injection and address space deduction
-// These are builtins that can be used from both js and wasm
-#pragma cheerp env none
-#if defined(__CHEERP__) && (defined(INTERNAL_MUSL) || !defined(__GENERICJS__))
+#if defined(__CHEERP__) && (defined(__ASMJS__))
 #define MAYBE_ASMJS __attribute((cheerp_asmjs))
 #else
 #define MAYBE_ASMJS
@@ -34,7 +31,6 @@ MAYBE_ASMJS void *memcpy (void *__restrict, const void *__restrict, size_t);
 MAYBE_ASMJS void *memmove (void *, const void *, size_t);
 MAYBE_ASMJS void *memset (void *, int, size_t);
 #undef MAYBE_ASMJS
-#pragma cheerp env reset
 int memcmp (const void *, const void *, size_t);
 void *memchr (const void *, int, size_t);
 

--- a/src/malloc/free.c
+++ b/src/malloc/free.c
@@ -1,5 +1,4 @@
-#define INTERNAL_MUSL
-#include <stdlib.h>
+//#include <stdlib.h>
 
 //void free(void *p)
 //{

--- a/src/string/memcpy.c
+++ b/src/string/memcpy.c
@@ -1,3 +1,4 @@
+#if !defined(__CHEERP__) || defined(__ASMJS__)
 #define INTERNAL_MUSL
 #include <string.h>
 #include <stdint.h>
@@ -135,3 +136,5 @@ __attribute__ ((__weak__, alias("__memcpy"))) void* memcpy(void *restrict dest, 
 __attribute((cheerp_asmjs))
 #endif
 __attribute__ ((alias("__memcpy"))) void* __cheerp_memcpy(void *restrict dest, const void *restrict src, size_t n);
+
+#endif

--- a/src/string/memmove.c
+++ b/src/string/memmove.c
@@ -1,3 +1,4 @@
+#if !defined(__CHEERP__) || defined(__ASMJS__)
 #define INTERNAL_MUSL
 #include <string.h>
 #include <stdint.h>
@@ -53,3 +54,5 @@ __attribute__ ((__weak__, alias("__memmove"))) void* memmove(void*dest, const vo
 __attribute((cheerp_asmjs))
 #endif
 __attribute__ ((alias("__memmove"))) void* __cheerp_memmove(void*dest, const void *src, size_t n);
+
+#endif

--- a/src/string/memset.c
+++ b/src/string/memset.c
@@ -1,3 +1,4 @@
+#if !defined(__CHEERP__) || defined(__ASMJS__)
 #define INTERNAL_MUSL
 #include <string.h>
 #include <stdint.h>
@@ -101,3 +102,5 @@ __attribute__ ((__weak__, alias("__memset"))) void* memset(void* s, int  c, size
 __attribute((cheerp_asmjs))
 #endif
 __attribute__ ((alias("__memset"))) void* __cheerp_memset(void* s, int  c, size_t n);
+
+#endif


### PR DESCRIPTION
We don't support wasm code in the genericjs target anyway, and it simplify things for the upcoming address space rework in cheerp.