### PR TITLE
thread: add __startThread bootstrap for spawned threads

### DIFF
--- a/crt/cheerp/crt1.c
+++ b/crt/cheerp/crt1.c
@@ -67,3 +67,19 @@ void __cheerp_init_tls()
 		a_crash();
 #endif
 }
+
+#if defined(__ASMJS__) || defined(__wasm__)
+__attribute__((cheerp_jsexport))
+weak void __startThread(int func, int arg, int tp)
+{
+#if defined(__wasm__) && !defined(__CHEERP__)
+	void *tls_base = (void*)(tp-__clang_wasm_tls_size_aligned());
+	__clang_wasm_set_tls_base((tls_base));
+#else
+	__builtin_cheerp_set_thread_pointer(tp);
+#endif
+	int(*f)(void*) = (int(*)(void*))func;
+	void* a = (void*)arg;
+	f(a);
+}
+#endif


### PR DESCRIPTION
Entry point the runtime jumps to on a new thread: install the TLS base and stack pointer, then call the thread function.

The cheerp and upstream-clang paths put __tls_base at opposite ends of the TLS area: cheerp's thread pointer is the area itself, while for upstream clang (__wasm__ && !__CHEERP__) __get_tp() is __tls_base + tls_size. So on the upstream-clang path the bootstrap sets __tls_base to (thread_pointer - tls_size_aligned); using the raw clone tls value directly would leave __get_tp() off by tls_size, corrupting the TCB of any spawned thread that touches a native thread-local.
