### PR TITLE
malloc: enable usage of mmap

### DIFF
--- a/include/sys/mman.h
+++ b/include/sys/mman.h
@@ -36,6 +36,7 @@ extern "C" {
 #define MAP_HUGETLB    0x40000
 #define MAP_SYNC       0x80000
 #define MAP_FIXED_NOREPLACE 0x100000
+#define MAP_UNINITIALIZED 0x4000000
 #define MAP_FILE       0
 
 #define MAP_HUGE_SHIFT 26

--- a/src/malloc/dlmalloc/malloc-params.h
+++ b/src/malloc/dlmalloc/malloc-params.h
@@ -1,4 +1,7 @@
-#define HAVE_MMAP 0
+#define HAVE_MMAP 1
+#define HAVE_MREMAP 0
+/* Mappings are requested with MAP_UNINITIALIZED, so calloc must always clear */
+#define MMAP_CLEARS 0
 #define HAVE_MORECORE 1
 #define MORECORE_CONTIGUOUS 1
 #define MORECORE_CANNOT_TRIM 1
@@ -8,6 +11,12 @@
 
 void* dlmalloc_morecore(int size);
 #define MORECORE dlmalloc_morecore
+
+void* dlmalloc_mmap(__SIZE_TYPE__ size);
+int dlmalloc_munmap(void* addr, __SIZE_TYPE__ size);
+#define MMAP(s) dlmalloc_mmap(s)
+#define DIRECT_MMAP(s) dlmalloc_mmap(s)
+#define MUNMAP(a, s) dlmalloc_munmap((a), (s))
 
 #define ABORT __builtin_unreachable()
 #define NO_MALLOC_STATS 1

--- a/src/malloc/dlmalloc/morecore.c
+++ b/src/malloc/dlmalloc/morecore.c
@@ -1,4 +1,5 @@
 #if !defined(__CHEERP__) || defined(__ASMJS__)
+#include <sys/mman.h>
 #include "syscall.h"
 #include "malloc-params.h"
 
@@ -25,5 +26,18 @@ void* dlmalloc_morecore(int size)
 	char* base = end;
 	end += size;
 	return base;
+}
+
+// The host may honor MAP_UNINITIALIZED and skip zero-filling; dlmalloc is
+// built with MMAP_CLEARS 0 so calloc never relies on mapped memory being zero
+void* dlmalloc_mmap(size_t size)
+{
+	return __mmap(0, size, PROT_READ|PROT_WRITE,
+	              MAP_PRIVATE|MAP_ANONYMOUS|MAP_UNINITIALIZED, -1, 0);
+}
+
+int dlmalloc_munmap(void* addr, size_t size)
+{
+	return __munmap(addr, size);
 }
 #endif


### PR DESCRIPTION
for now, only cheerpos will actually use mmap, and other targets return
-1. dlmalloc should handle this gracefully and fall back to brk.
We also add the flag MAP_UNINITIALIZED to avoid the overhead of zeroing
the bytes preemptively (calloc will do it on demand).
