### PR TITLE
fix __SYSCALL_ATTR so that the arg is not expanded too soon

### DIFF
--- a/arch/cheerp/syscall_arch.h
+++ b/arch/cheerp/syscall_arch.h
@@ -8,11 +8,11 @@
 #ifndef SYSCALL_DEF
 #define __SYSCALL_DEF_DECL
 #if defined(__wasm__) && !defined(__CHEERP__)
-#define __SYSCALL_ATTR(name) __attribute__((import_module("i"), import_name("__syscall_" #name)))
+#define __SYSCALL_ATTR(namestr) __attribute__((import_module("i"), import_name("__syscall_" namestr)))
 #else
-#define __SYSCALL_ATTR(name)
+#define __SYSCALL_ATTR(namestr)
 #endif
-#define SYSCALL_DEF(name, ...) long __SYSCALL_ATTR(name) __syscall_ ## name(__VA_ARGS__)
+#define SYSCALL_DEF(name, ...) long __SYSCALL_ATTR(#name) __syscall_ ## name(__VA_ARGS__)
 #endif
 
 struct iovec;


### PR DESCRIPTION
Passing name through a nested macro call would macro-expand it first,
so a `name` that happens to be a macro in scope (e.g. `#define prlimit64 prlimit`
under _GNU_SOURCE) would yield an import_name that disagrees with the
`##`-pasted symbol name, which the wasm linker rejects as an import name mismatch.
Both `#name` and `## name` must see the raw argument. */
